### PR TITLE
-ClassA::methodA@INGRESS::STACK::[filterCondition]

### DIFF
--- a/src/main/java/com/asm/mja/rule/Rule.java
+++ b/src/main/java/com/asm/mja/rule/Rule.java
@@ -17,6 +17,7 @@ public class Rule {
     private String customCode;
     private int lineNumber;
 
+    private String filterName;
     public Rule(String className, String methodName, Event event, Action action, int lineNumber) {
         this(className, methodName, event, action, null, lineNumber);
     }
@@ -29,6 +30,16 @@ public class Rule {
         this.lineNumber = lineNumber;
         this.customCode = customCode;
     }
+    public Rule(String className, String methodName, Event event, Action action, String customCode, int lineNumber,String filterName) {
+        this.className = className;
+        this.methodName = methodName;
+        this.event = event;
+        this.action = action;
+        this.lineNumber = lineNumber;
+        this.customCode = customCode;
+        this.filterName=filterName;
+    }
+
 
     public String getClassName() {
         return className;
@@ -76,5 +87,12 @@ public class Rule {
 
     public void setCustomCode(String customCode) {
         this.customCode = customCode;
+    }
+
+    public void setFilterName(String filterName){
+        this.filterName=filterName;
+    }
+    public String getFilterName(){
+        return filterName;
     }
 }

--- a/src/main/java/com/asm/mja/rule/RuleParser.java
+++ b/src/main/java/com/asm/mja/rule/RuleParser.java
@@ -44,6 +44,13 @@ public class RuleParser {
                     }
                     Action action = Action.valueOf(parts[3]);
 
+                    String filterName=null;
+                    if(action==Action.STACK && parts.length >4){
+                        Matcher matcher=addPattern.matcher(parts[4]);
+                        if(matcher.find()){
+                            filterName=matcher.group(1);
+                        }
+                    }
                     String customCode = null;
                     if (action == Action.ADD && parts.length > 4) {
                         Matcher matcher = addPattern.matcher(parts[4]);
@@ -52,7 +59,7 @@ public class RuleParser {
                         }
                     }
 
-                    return new Rule(className, methodName, event, action, customCode, lineNumber);
+                    return new Rule(className, methodName, event, action, customCode, lineNumber ,filterName);
                 })
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
If filterName is provided, the generated code checks whether any stack frame contains the specified method, class, or package name. If the filter is not found in the stack trace, logging is skipped. When no filter is set, the stack trace is logged unconditionally. The stack trace is recorded using TraceFileLogger, including the class, method, and event context for better traceability.

## Summary by Sourcery

Introduce an optional filterName parameter for stack-based rules and propagate it through the transformation pipeline to enable conditional stack trace logging only when the specified filter is found in the call stack.

New Features:
- Add filterName field to Rule class with constructors, getters, and setters
- Extend RuleParser to extract filterName from rule definitions for STACK actions
- Propagate filterName argument through ingress, egress, and codepoint transformation methods

Enhancements:
- Inject conditional logging logic in getStack instrumentation to skip TraceFileLogger calls when filterName is not found in the stack
- Log the full stack trace with class, method, and event context using TraceFileLogger